### PR TITLE
feat: build SPA frontend shell with sidebar navigation

### DIFF
--- a/backend/yes_chef_mcp/api/views.py
+++ b/backend/yes_chef_mcp/api/views.py
@@ -136,3 +136,10 @@ async def grocery_list_view(
     data: dict[str, object] = {"grocery_list": grocery.model_dump()}
     html = _inject_data(DIST_DIR / "grocery-list.html", data)
     return HTMLResponse(content=html)
+
+
+@router.get("/views/app", response_class=HTMLResponse)
+async def spa_view() -> HTMLResponse:
+    """Serve the main SPA frontend (no data injection needed)."""
+    html_path = DIST_DIR / "app.html"
+    return HTMLResponse(content=html_path.read_text())

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Yes Chef — Meal Planning</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Lato:wght@400;500;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/entries/app.tsx"></script>
+</body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3112,7 +3111,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3182,7 +3180,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3485,7 +3482,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3527,7 +3523,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3635,7 +3630,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3848,7 +3842,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,124 @@
+/**
+ * API client for the Yes Chef SPA frontend.
+ *
+ * Fetches data from the FastAPI REST endpoints instead of reading
+ * injected JSON (which is the MCP entry approach).
+ */
+
+import type {
+  GroceryList,
+  MacroSummary,
+  MacroTarget,
+  PlanSummary,
+  RecipeHit,
+} from "./types.ts";
+
+const API_BASE = "/api";
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json", ...init?.headers },
+    ...init,
+  });
+  if (!res.ok) {
+    throw new Error(`API ${res.status}: ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/* ── Recipes ─────────────────��───────────────────────────────────────── */
+
+interface RecipeSearchResponse {
+  hits: RecipeHit[];
+  next_cursor: string | null;
+  total_count: number;
+}
+
+export async function fetchRecipes(
+  q?: string,
+  category?: string,
+  tags?: string[],
+  maxResults = 20,
+): Promise<RecipeHit[]> {
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  if (category) params.set("category", category);
+  if (tags?.length) params.set("tags", tags.join(","));
+  params.set("max_results", String(maxResults));
+
+  const result = await apiFetch<RecipeSearchResponse>(`/recipes?${params}`);
+  return result.hits;
+}
+
+/* ── Macro Targets ────────��──────────────────────────────────────────── */
+
+export async function fetchMacroTargets(
+  memberId?: string,
+): Promise<MacroTarget[]> {
+  if (!memberId) return [];
+  return apiFetch<MacroTarget[]>(`/members/${memberId}/targets`);
+}
+
+export async function saveMacroTarget(
+  memberId: string,
+  target: { name?: string; calories: number; protein_g: number; carbs_g: number; fat_g: number },
+): Promise<MacroTarget> {
+  return apiFetch<MacroTarget>(`/members/${memberId}/targets`, {
+    method: "POST",
+    body: JSON.stringify({ ...target, set_active: true }),
+  });
+}
+
+/* ── Meal Plans ──────��──────────────────────────���────────────────────── */
+
+interface MealPlanListItem {
+  id: string;
+  family_id: string;
+  name: string;
+  start_date: string;
+  days: number;
+}
+
+export async function fetchPlans(): Promise<MealPlanListItem[]> {
+  return apiFetch<MealPlanListItem[]>("/plans");
+}
+
+export async function fetchPlanSummary(
+  planId: string,
+  memberId?: string,
+): Promise<PlanSummary> {
+  const params = new URLSearchParams({ detail: "full" });
+  if (memberId) params.set("member_id", memberId);
+  return apiFetch<PlanSummary>(`/plans/${planId}/summary?${params}`);
+}
+
+/* ── Grocery ───���─────────────────────────────��───────────────────────── */
+
+export async function fetchGroceryList(
+  planId: string,
+  mergeSimilar = true,
+  excludePantry = true,
+): Promise<GroceryList> {
+  const params = new URLSearchParams({
+    merge_similar: String(mergeSimilar),
+    exclude_pantry: String(excludePantry),
+  });
+  return apiFetch<GroceryList>(`/plans/${planId}/grocery-list?${params}`);
+}
+
+/* ── Members ��────────────────────────────���───────────────────────────── */
+
+interface FamilyMember {
+  id: string;
+  family_id: string;
+  name: string;
+  role: string;
+  is_default: boolean;
+  active_target: MacroSummary | null;
+}
+
+export async function fetchFamilyMembers(
+  familyId: string,
+): Promise<FamilyMember[]> {
+  return apiFetch<FamilyMember[]>(`/families/${familyId}/members`);
+}

--- a/frontend/src/components/AppShell/AppShell.module.css
+++ b/frontend/src/components/AppShell/AppShell.module.css
@@ -1,0 +1,27 @@
+/* ── App Shell ────────────────────────────────────────────────────────── */
+
+.shell {
+  min-height: 100vh;
+}
+
+/* ── Main Content ─────────────────────────────────────────────────────── */
+
+.content {
+  padding-top: 56px;
+  min-height: 100vh;
+  transition: margin-left 0.2s ease;
+}
+
+.contentCollapsed {
+  margin-left: 64px;
+}
+
+.contentExpanded {
+  margin-left: 200px;
+}
+
+.contentInner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--space-4);
+}

--- a/frontend/src/components/AppShell/AppShell.tsx
+++ b/frontend/src/components/AppShell/AppShell.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from "react";
+import { TopBar } from "../TopBar";
+import { Sidebar } from "../Sidebar";
+import type { Page } from "../Sidebar";
+import styles from "./AppShell.module.css";
+
+interface AppShellProps {
+  activePage: Page;
+  onNavigate: (page: Page) => void;
+  sidebarExpanded: boolean;
+  onToggleSidebar: () => void;
+  children: ReactNode;
+}
+
+export function AppShell({
+  activePage,
+  onNavigate,
+  sidebarExpanded,
+  onToggleSidebar,
+  children,
+}: AppShellProps) {
+  return (
+    <div className={styles.shell}>
+      <TopBar onToggleSidebar={onToggleSidebar} />
+      <Sidebar
+        activePage={activePage}
+        onNavigate={onNavigate}
+        isExpanded={sidebarExpanded}
+      />
+      <main
+        className={`${styles.content} ${sidebarExpanded ? styles.contentExpanded : styles.contentCollapsed}`}
+      >
+        <div className={styles.contentInner}>
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/AppShell/index.ts
+++ b/frontend/src/components/AppShell/index.ts
@@ -1,0 +1,1 @@
+export { AppShell } from "./AppShell";

--- a/frontend/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/src/components/Sidebar/Sidebar.module.css
@@ -1,0 +1,111 @@
+/* ── Sidebar ──────────────────────────────────────────────────────────── */
+
+.sidebar {
+  position: fixed;
+  top: 56px;
+  left: 0;
+  bottom: 0;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  z-index: 10;
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.collapsed {
+  width: 64px;
+}
+
+.expanded {
+  width: 200px;
+}
+
+/* ── Nav List ─────────────────────────────────────────────────────────── */
+
+.navList {
+  list-style: none;
+  padding: var(--space-2) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* ── Nav Item ─────────────────────────────────────────────────────────── */
+
+.navItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  gap: var(--space-3);
+  background: none;
+  border: none;
+  border-left: 3px solid transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+  font: var(--text-small);
+  text-decoration: none;
+  outline: none;
+}
+
+.navItem[data-hovered] {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.navItem[data-pressed] {
+  background: var(--color-surface-hover);
+}
+
+.navItem[data-focus-visible] {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
+.navItemActive {
+  color: var(--color-primary);
+  border-left-color: var(--color-primary);
+  background: var(--color-primary-bg);
+}
+
+.navItemActive[data-hovered] {
+  color: var(--color-primary);
+}
+
+/* ── Icon & Label ─────────────────────────────────────────────────────── */
+
+.navIcon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.navLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* When collapsed, center icon and hide label */
+.collapsed .navItem {
+  flex-direction: column;
+  padding: var(--space-2) var(--space-1);
+  gap: var(--space-1);
+  border-left: none;
+  justify-content: center;
+}
+
+.collapsed .navItemActive {
+  border-left: none;
+  border-bottom: none;
+  background: var(--color-primary-bg);
+}
+
+.collapsed .navLabel {
+  font: var(--text-badge);
+  text-align: center;
+}

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,101 @@
+import { type ReactNode } from "react";
+import { Button } from "react-aria-components";
+import styles from "./Sidebar.module.css";
+
+/* ── Page Type ────────────────────────────────────────────────────────── */
+
+export type Page = "macros" | "recipes" | "calendar" | "grocery";
+
+/* ── SVG Icons ────────────────────────────────────────────────────────── */
+
+function TargetIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="6" />
+      <circle cx="12" cy="12" r="2" />
+    </svg>
+  );
+}
+
+function BookIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+      <line x1="8" y1="7" x2="16" y2="7" />
+      <line x1="8" y1="11" x2="13" y2="11" />
+    </svg>
+  );
+}
+
+function CalendarIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="0" ry="0" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+function CartIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="9" cy="21" r="1" />
+      <circle cx="20" cy="21" r="1" />
+      <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+    </svg>
+  );
+}
+
+/* ── Nav Items ────────────────────────────────────────────────────────── */
+
+interface NavItem {
+  page: Page;
+  label: string;
+  icon: ReactNode;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { page: "macros", label: "Macros", icon: <TargetIcon /> },
+  { page: "recipes", label: "Recipes", icon: <BookIcon /> },
+  { page: "calendar", label: "Calendar", icon: <CalendarIcon /> },
+  { page: "grocery", label: "Grocery", icon: <CartIcon /> },
+];
+
+/* ── Sidebar ──────────────────────────────────────────────────────────── */
+
+interface SidebarProps {
+  activePage: Page;
+  onNavigate: (page: Page) => void;
+  isExpanded: boolean;
+}
+
+export function Sidebar({ activePage, onNavigate, isExpanded }: SidebarProps) {
+  return (
+    <nav
+      className={`${styles.sidebar} ${isExpanded ? styles.expanded : styles.collapsed}`}
+      aria-label="Main navigation"
+    >
+      <ul className={styles.navList}>
+        {NAV_ITEMS.map(({ page, label, icon }) => {
+          const isActive = activePage === page;
+          return (
+            <li key={page}>
+              <Button
+                className={`${styles.navItem} ${isActive ? styles.navItemActive : ""}`}
+                onPress={() => onNavigate(page)}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <span className={styles.navIcon}>{icon}</span>
+                <span className={styles.navLabel}>{label}</span>
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/components/Sidebar/index.ts
+++ b/frontend/src/components/Sidebar/index.ts
@@ -1,0 +1,2 @@
+export { Sidebar } from "./Sidebar";
+export type { Page } from "./Sidebar";

--- a/frontend/src/components/TopBar/TopBar.module.css
+++ b/frontend/src/components/TopBar/TopBar.module.css
@@ -1,0 +1,101 @@
+/* ── TopBar ───────────────────────────────────────────────────────────── */
+
+.topBar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: var(--elevation-1);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-3);
+}
+
+/* ── Left Section ─────────────────────────────────────────────────────── */
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.hamburger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  border-radius: var(--radius-none);
+  transition: background 0.15s ease;
+}
+
+.hamburger[data-hovered] {
+  background: var(--color-surface-hover);
+}
+
+.hamburger[data-pressed] {
+  background: var(--color-surface-hover);
+}
+
+.hamburger[data-focus-visible] {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+/* ── Brand ────────────────────────────────────────────────────────────── */
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.brandName {
+  font: var(--text-heading);
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+/* ── Right Section ────────────────────────────────────────────────────── */
+
+.right {
+  display: flex;
+  align-items: center;
+}
+
+.signIn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font: var(--text-label);
+  cursor: pointer;
+  border-radius: var(--radius-none);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.signIn[data-hovered] {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.signIn[data-pressed] {
+  background: var(--color-surface-hover);
+}
+
+.signIn[data-focus-visible] {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/TopBar/TopBar.tsx
+++ b/frontend/src/components/TopBar/TopBar.tsx
@@ -1,0 +1,79 @@
+import { Button } from "react-aria-components";
+import styles from "./TopBar.module.css";
+
+/* ── Hamburger Icon ────────────────────────────────────��──────────────── */
+
+function HamburgerIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  );
+}
+
+/* ���─ Logo Icon ────────────────────────────────────────────────────────── */
+
+function LogoIcon() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
+      <rect width="32" height="32" rx="0" fill="var(--color-primary)" />
+      <text
+        x="16"
+        y="22"
+        textAnchor="middle"
+        fill="var(--color-text-inverse)"
+        fontFamily="var(--font-heading)"
+        fontSize="18"
+        fontWeight="700"
+      >
+        Y
+      </text>
+    </svg>
+  );
+}
+
+/* ── User Icon ────────────────────────────────────────────────────────── */
+
+function UserIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+
+/* ── TopBar ───────────────────────────────────────────────────────────── */
+
+interface TopBarProps {
+  onToggleSidebar: () => void;
+}
+
+export function TopBar({ onToggleSidebar }: TopBarProps) {
+  return (
+    <header className={styles.topBar}>
+      <div className={styles.left}>
+        <Button
+          className={styles.hamburger}
+          onPress={onToggleSidebar}
+          aria-label="Toggle sidebar"
+        >
+          <HamburgerIcon />
+        </Button>
+        <div className={styles.brand}>
+          <LogoIcon />
+          <span className={styles.brandName}>Yes Chef</span>
+        </div>
+      </div>
+
+      <div className={styles.right}>
+        <Button className={styles.signIn}>
+          <UserIcon />
+          <span>Sign In</span>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/TopBar/index.ts
+++ b/frontend/src/components/TopBar/index.ts
@@ -1,0 +1,1 @@
+export { TopBar } from "./TopBar";

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -5,3 +5,7 @@ export { MacroBadge, MacroBadgeRow } from "./MacroBadge";
 export { CaloriePanel, SliderPanel } from "./MacroTargetEditor";
 export type { MacroKey, MacroConfig, MacroTargetEditorProps } from "./MacroTargetEditor";
 export { ProgressBar } from "./ProgressBar";
+export { AppShell } from "./AppShell";
+export { Sidebar } from "./Sidebar";
+export type { Page } from "./Sidebar";
+export { TopBar } from "./TopBar";

--- a/frontend/src/entries/app.tsx
+++ b/frontend/src/entries/app.tsx
@@ -1,0 +1,56 @@
+import { StrictMode, useState, useCallback } from "react";
+import { createRoot } from "react-dom/client";
+import { AppShell } from "../components";
+import type { Page } from "../components";
+import {
+  MacroSetterPage,
+  RecipeSelectorPage,
+  WeeklyCalendarPage,
+  GroceryListPage,
+} from "../pages";
+import "../global.css";
+
+/* ── Page Router ──────────────────────────────────────────────────────── */
+
+function PageContent({ page }: { page: Page }) {
+  switch (page) {
+    case "macros":
+      return <MacroSetterPage />;
+    case "recipes":
+      return <RecipeSelectorPage />;
+    case "calendar":
+      return <WeeklyCalendarPage />;
+    case "grocery":
+      return <GroceryListPage />;
+  }
+}
+
+/* ── App ──────────────────────────────────────────────────────────────── */
+
+function App() {
+  const [activePage, setActivePage] = useState<Page>("macros");
+  const [sidebarExpanded, setSidebarExpanded] = useState(false);
+
+  const handleToggleSidebar = useCallback(() => {
+    setSidebarExpanded((prev) => !prev);
+  }, []);
+
+  return (
+    <AppShell
+      activePage={activePage}
+      onNavigate={setActivePage}
+      sidebarExpanded={sidebarExpanded}
+      onToggleSidebar={handleToggleSidebar}
+    >
+      <PageContent page={activePage} />
+    </AppShell>
+  );
+}
+
+/* ── Mount ─────────────────────────────────────────────────────────────── */
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/frontend/src/pages/GroceryListPage.module.css
+++ b/frontend/src/pages/GroceryListPage.module.css
@@ -1,0 +1,174 @@
+/* ── GroceryListPage ─────────────────────────────────────────────────── */
+
+.container {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.loading {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+  font: var(--text-body);
+}
+
+/* ── Plan Selector ───────────────────────────────────────────────────── */
+
+.planSelector {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+/* ── Category Header ──────────────────────────────────────────────────── */
+
+.categoryHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) 0;
+  margin-top: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+}
+
+.categoryName {
+  font: var(--text-small-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text);
+}
+
+.categoryNameDone {
+  color: var(--color-text-dim);
+}
+
+.categoryCount {
+  font: var(--text-small);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ── Checklist Item ───────────────────────────────────────────────────── */
+
+.checklistItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-none);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.checklistItem[data-hovered] {
+  background: var(--color-surface-hover);
+}
+
+.checkboxWrapper {
+  flex-shrink: 0;
+}
+
+.itemDetails {
+  flex: 1;
+}
+
+.itemName {
+  font: var(--text-body);
+  color: var(--color-text);
+  transition: color 0.15s ease;
+}
+
+.itemNameChecked {
+  color: var(--color-text-dim);
+  text-decoration: line-through;
+}
+
+.itemQty {
+  margin-left: var(--space-2);
+  font: var(--text-small);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.recipeSources {
+  font: var(--text-badge);
+  color: var(--color-text-dim);
+  max-width: 120px;
+  text-align: right;
+  line-height: 20px;
+}
+
+/* ── Summary Bar ──────────────────────────────────────────────────────── */
+
+.summaryCard {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.summaryTrackWrapper {
+  flex: 1;
+}
+
+.summaryTrack {
+  height: var(--space-2);
+  background: var(--color-border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.summaryFill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  transition: width 0.3s ease;
+  width: var(--progress-pct);
+}
+
+.summaryFillActive {
+  background: var(--color-primary);
+}
+
+.summaryFillComplete {
+  background: var(--color-success);
+}
+
+.summarySubtext {
+  font: var(--text-small);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+}
+
+.summaryCount {
+  font: var(--text-mono-large);
+  color: var(--color-text);
+  min-width: 56px;
+  text-align: center;
+}
+
+.summaryCountDone {
+  color: var(--color-success);
+}
+
+/* ── Empty State ──────────────────────────────────────────────────────── */
+
+.empty {
+  text-align: center;
+  padding: var(--space-5);
+  color: var(--color-text-muted);
+}
+
+/* ─�� Sticky Footer ────────────────────────────────────────────────────── */
+
+.footer {
+  margin-top: var(--space-5);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  bottom: var(--space-4);
+  background: var(--color-bg);
+  padding: var(--space-3) 0;
+}

--- a/frontend/src/pages/GroceryListPage.module.css
+++ b/frontend/src/pages/GroceryListPage.module.css
@@ -103,18 +103,13 @@
 /* ── Summary Bar ──────────────────────────────────────────────────────── */
 
 .summaryCard {
-  display: flex;
-  align-items: center;
   gap: var(--space-4);
   margin-bottom: var(--space-4);
 }
 
-.summaryTrackWrapper {
-  flex: 1;
-}
-
 .summaryTrack {
   height: var(--space-2);
+  width: 100%;
   background: var(--color-border);
   border-radius: var(--radius-pill);
   overflow: hidden;

--- a/frontend/src/pages/GroceryListPage.tsx
+++ b/frontend/src/pages/GroceryListPage.tsx
@@ -116,22 +116,26 @@ function SummaryBar({ total, checked }: { total: number; checked: number }) {
   const pct = total > 0 ? (checked / total) * 100 : 0;
 
   return (
-    <Card className={styles.summaryCard}>
-      <div className={styles.summaryTrackWrapper}>
+    <Card
+      className={styles.summaryCard}
+      pretitle="Shopping Status"
+      title={
         <div className={styles.summaryTrack}>
           <div
             className={`${styles.summaryFill} ${pct === 100 ? styles.summaryFillComplete : styles.summaryFillActive}`}
             {...{ style: { "--progress-pct": `${pct}%` } as React.CSSProperties }}
           />
         </div>
-        <div className={styles.summarySubtext}>
-          {checked} of {total} items checked off
+      }
+      subtitle={
+        <div>{checked} of {total} items checked off</div>
+      }
+      trailingMedia={
+        <div className={`${styles.summaryCount} ${remaining === 0 ? styles.summaryCountDone : ""}`}>
+          {remaining === 0 ? "\u2713" : remaining}
         </div>
-      </div>
-      <div className={`${styles.summaryCount} ${remaining === 0 ? styles.summaryCountDone : ""}`}>
-        {remaining === 0 ? "\u2713" : remaining}
-      </div>
-    </Card>
+      }
+    />
   );
 }
 

--- a/frontend/src/pages/GroceryListPage.tsx
+++ b/frontend/src/pages/GroceryListPage.tsx
@@ -1,0 +1,288 @@
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { Checkbox } from "react-aria-components";
+import { Button, Card } from "../components";
+import type { GroceryItem } from "../types.ts";
+import { fetchPlans, fetchGroceryList } from "../api.ts";
+import styles from "./GroceryListPage.module.css";
+
+/* ── Plan Selector ───────────────────────────────────────────────────── */
+
+interface PlanOption {
+  id: string;
+  name: string;
+}
+
+function PlanSelector({
+  plans,
+  selectedId,
+  onSelect,
+}: {
+  plans: PlanOption[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (plans.length === 0) return null;
+
+  return (
+    <div className={styles.planSelector}>
+      {plans.map((plan) => (
+        <Button
+          key={plan.id}
+          variant={selectedId === plan.id ? "primary" : "secondary"}
+          size="sm"
+          onPress={() => onSelect(plan.id)}
+        >
+          {plan.name}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+/* ── Category Header ──────────────────────────────────────────────────── */
+
+function CategoryHeader({
+  name,
+  count,
+  checkedCount,
+  onCheckAll,
+}: {
+  name: string;
+  count: number;
+  checkedCount: number;
+  onCheckAll: () => void;
+}) {
+  const allChecked = checkedCount === count;
+
+  return (
+    <div className={styles.categoryHeader} onClick={onCheckAll}>
+      <h2 className={`${styles.categoryName} ${allChecked ? styles.categoryNameDone : ""}`}>
+        {name}
+      </h2>
+      <span className={styles.categoryCount}>
+        {checkedCount}/{count}
+      </span>
+    </div>
+  );
+}
+
+/* ── Checklist Item ───────────────────────────────────────────────────── */
+
+function ChecklistItem({
+  item,
+  isChecked,
+  onToggle,
+}: {
+  item: GroceryItem;
+  isChecked: boolean;
+  onToggle: () => void;
+}) {
+  const displayQty = item.quantity
+    ? `${item.quantity}${item.unit ? " " + item.unit : ""}`
+    : "";
+
+  return (
+    <div className={styles.checklistItem} onClick={onToggle}>
+      <div className={styles.checkboxWrapper}>
+        <Checkbox
+          isSelected={isChecked}
+          onChange={onToggle}
+          aria-label={`${item.name}${displayQty ? ` (${displayQty})` : ""}`}
+        />
+      </div>
+
+      <div className={styles.itemDetails}>
+        <span className={`${styles.itemName} ${isChecked ? styles.itemNameChecked : ""}`}>
+          {item.name}
+        </span>
+        {displayQty && (
+          <span className={styles.itemQty}>{displayQty}</span>
+        )}
+      </div>
+
+      {item.recipe_sources.length > 0 && (
+        <div className={styles.recipeSources}>
+          {item.recipe_sources.join(", ")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Summary Bar ──────────────────────────────────────────────────────── */
+
+function SummaryBar({ total, checked }: { total: number; checked: number }) {
+  const remaining = total - checked;
+  const pct = total > 0 ? (checked / total) * 100 : 0;
+
+  return (
+    <Card className={styles.summaryCard}>
+      <div className={styles.summaryTrackWrapper}>
+        <div className={styles.summaryTrack}>
+          <div
+            className={`${styles.summaryFill} ${pct === 100 ? styles.summaryFillComplete : styles.summaryFillActive}`}
+            {...{ style: { "--progress-pct": `${pct}%` } as React.CSSProperties }}
+          />
+        </div>
+        <div className={styles.summarySubtext}>
+          {checked} of {total} items checked off
+        </div>
+      </div>
+      <div className={`${styles.summaryCount} ${remaining === 0 ? styles.summaryCountDone : ""}`}>
+        {remaining === 0 ? "\u2713" : remaining}
+      </div>
+    </Card>
+  );
+}
+
+/* ── Page Component ──────────────────────────────────────────────────── */
+
+interface IndexedItem extends GroceryItem {
+  _idx: number;
+}
+
+interface CategoryGroup {
+  category: string;
+  items: IndexedItem[];
+}
+
+export function GroceryListPage() {
+  const [plans, setPlans] = useState<PlanOption[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const [items, setItems] = useState<GroceryItem[]>([]);
+  const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchPlans()
+      .then((result) => {
+        const options = result.map((p) => ({ id: p.id, name: p.name }));
+        setPlans(options);
+        if (options.length > 0) {
+          setSelectedPlanId(options[0]!.id);
+        }
+      })
+      .catch(() => { /* API unavailable */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedPlanId) return;
+    setLoading(true);
+    setCheckedIds(new Set());
+    fetchGroceryList(selectedPlanId)
+      .then((result) => setItems(result.items))
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false));
+  }, [selectedPlanId]);
+
+  const toggle = useCallback((idx: number) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
+  const checkAll = useCallback(
+    (category: string) => {
+      setCheckedIds((prev) => {
+        const next = new Set(prev);
+        items.forEach((item, idx) => {
+          if ((item.category || "other") === category) next.add(idx);
+        });
+        return next;
+      });
+    },
+    [items],
+  );
+
+  const grouped: CategoryGroup[] = useMemo(() => {
+    const groups: Record<string, IndexedItem[]> = {};
+    items.forEach((item, idx) => {
+      const cat = item.category || "other";
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat]!.push({ ...item, _idx: idx });
+    });
+    const sorted = Object.keys(groups).sort((a, b) => {
+      if (a === "other") return 1;
+      if (b === "other") return -1;
+      return a.localeCompare(b);
+    });
+    return sorted.map((cat) => ({ category: cat, items: groups[cat]! }));
+  }, [items]);
+
+  if (loading && items.length === 0) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading grocery list...</div>
+      </div>
+    );
+  }
+
+  if (plans.length === 0) {
+    return (
+      <div className={styles.container}>
+        <div className="view-header">
+          <h1>Grocery List</h1>
+          <p>No meal plans found. Create a plan to generate a grocery list.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className="view-header">
+        <h1>Grocery List</h1>
+        <p>Check off items you already have. Unchecked items will be your shopping list.</p>
+      </div>
+
+      <PlanSelector plans={plans} selectedId={selectedPlanId} onSelect={setSelectedPlanId} />
+
+      <SummaryBar total={items.length} checked={checkedIds.size} />
+
+      {grouped.map(({ category, items: catItems }) => {
+        const checkedCount = catItems.filter((it) => checkedIds.has(it._idx)).length;
+        return (
+          <div key={category}>
+            <CategoryHeader
+              name={category}
+              count={catItems.length}
+              checkedCount={checkedCount}
+              onCheckAll={() => {
+                if (checkedCount < catItems.length) checkAll(category);
+              }}
+            />
+            {catItems.map((item) => (
+              <ChecklistItem
+                key={item._idx}
+                item={item}
+                isChecked={checkedIds.has(item._idx)}
+                onToggle={() => toggle(item._idx)}
+              />
+            ))}
+          </div>
+        );
+      })}
+
+      {items.length === 0 && (
+        <div className={styles.empty}>
+          No items in the grocery list.
+        </div>
+      )}
+
+      <div className={styles.footer}>
+        <Button variant="ghost" onPress={() => setCheckedIds(new Set())}>
+          Uncheck All
+        </Button>
+        <Button isDisabled={items.length === 0}>
+          {checkedIds.size === items.length
+            ? "All Items In Pantry"
+            : `Confirm List (${items.length - checkedIds.size} items)`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MacroSetterPage.module.css
+++ b/frontend/src/pages/MacroSetterPage.module.css
@@ -1,0 +1,21 @@
+/* ── MacroSetterPage ─────────────────────────────────────────────────── */
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.loading {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+  font: var(--text-body);
+}
+
+/* ── Save feedback ───────────────────────────────────────────────────── */
+
+.saved {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: var(--color-text-inverse);
+}

--- a/frontend/src/pages/MacroSetterPage.tsx
+++ b/frontend/src/pages/MacroSetterPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback } from "react";
+import { Button, Card, CaloriePanel, SliderPanel } from "../components";
+import type { MacroKey, MacroConfig } from "../components";
+import { fetchMacroTargets, saveMacroTarget } from "../api.ts";
+import styles from "./MacroSetterPage.module.css";
+
+/* ── Macro definitions ───────────────────────────────────────────────── */
+
+function buildMacros(protein: number, carbs: number, fat: number): MacroConfig[] {
+  return [
+    { key: "protein", label: "Protein", grams: protein, min: 50, max: 350, step: 5, calPerGram: 4 },
+    { key: "carbs", label: "Carbs", grams: carbs, min: 50, max: 500, step: 5, calPerGram: 4 },
+    { key: "fat", label: "Fat", grams: fat, min: 20, max: 200, step: 5, calPerGram: 9 },
+  ];
+}
+
+/* ── Page Component ──────────────────────────��───────────────────────── */
+
+interface MacroSetterPageProps {
+  memberId?: string;
+}
+
+export function MacroSetterPage({ memberId }: MacroSetterPageProps) {
+  const [protein, setProtein] = useState(150);
+  const [carbs, setCarbs] = useState(200);
+  const [fat, setFat] = useState(65);
+  const [saved, setSaved] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [defaults, setDefaults] = useState<{ protein_g: number; carbs_g: number; fat_g: number } | null>(null);
+
+  const totalCalories = Math.round(protein * 4 + carbs * 4 + fat * 9);
+
+  useEffect(() => {
+    if (!memberId) {
+      setLoading(false);
+      return;
+    }
+    fetchMacroTargets(memberId)
+      .then((targets) => {
+        const active = targets.find((t) => t.is_active);
+        if (active) {
+          setProtein(active.protein_g);
+          setCarbs(active.carbs_g);
+          setFat(active.fat_g);
+          setDefaults({ protein_g: active.protein_g, carbs_g: active.carbs_g, fat_g: active.fat_g });
+        }
+      })
+      .catch(() => { /* API unavailable — use defaults */ })
+      .finally(() => setLoading(false));
+  }, [memberId]);
+
+  const handleMacroChange = useCallback((key: MacroKey, grams: number) => {
+    if (key === "protein") setProtein(grams);
+    else if (key === "carbs") setCarbs(grams);
+    else setFat(grams);
+  }, []);
+
+  const handleCalorieChange = useCallback((newCal: number) => {
+    if (totalCalories === 0) return;
+    const scale = newCal / totalCalories;
+    const clampSnap = (v: number, min: number, max: number, step: number) =>
+      Math.min(max, Math.max(min, Math.round(v / step) * step));
+    setProtein((p) => clampSnap(p * scale, 50, 350, 5));
+    setCarbs((c) => clampSnap(c * scale, 50, 500, 5));
+    setFat((f) => clampSnap(f * scale, 20, 200, 5));
+  }, [totalCalories]);
+
+  const handleSave = useCallback(() => {
+    if (memberId) {
+      saveMacroTarget(memberId, {
+        calories: totalCalories,
+        protein_g: protein,
+        carbs_g: carbs,
+        fat_g: fat,
+      }).catch(() => { /* handle error */ });
+    }
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }, [memberId, protein, carbs, fat, totalCalories]);
+
+  const handleReset = () => {
+    setProtein(defaults?.protein_g ?? 150);
+    setCarbs(defaults?.carbs_g ?? 200);
+    setFat(defaults?.fat_g ?? 65);
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading targets...</div>
+      </div>
+    );
+  }
+
+  const macros = buildMacros(protein, carbs, fat);
+
+  return (
+    <div className={styles.container}>
+      <div className="view-header">
+        <h1>Macro Targets</h1>
+        <p>Adjust your daily macro goals and see calorie impact in real time.</p>
+      </div>
+
+      <Card
+        pretitle="Daily Target"
+        title="Macro Targets"
+        subtitle="Drag the sliders or edit the calorie total directly."
+        leadingMedia={
+          <CaloriePanel
+            macros={macros}
+            totalCalories={totalCalories}
+            onCalorieChange={handleCalorieChange}
+          />
+        }
+        body={<SliderPanel macros={macros} onMacroChange={handleMacroChange} />}
+        footer={
+          <>
+            <Button variant="secondary" onPress={handleReset}>
+              Reset
+            </Button>
+            <Button
+              onPress={handleSave}
+              className={saved ? styles.saved : undefined}
+            >
+              {saved ? "Saved!" : "Save Targets"}
+            </Button>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/RecipeSelectorPage.module.css
+++ b/frontend/src/pages/RecipeSelectorPage.module.css
@@ -1,0 +1,132 @@
+/* ── RecipeSelectorPage ──────────────────────────────────────────────── */
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.loading {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+  font: var(--text-body);
+}
+
+/* ── Filter Bar ───────────────────────────────────────────────────────── */
+
+.filterBar {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+/* ── Recipe Grid ──────────────────────────────────────────────────────── */
+
+.recipeGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-3);
+}
+
+/* ── Recipe Card ──────────────────────────────────────────────────────── */
+
+.recipeCardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-2);
+}
+
+.recipeName {
+  font: var(--text-label);
+  color: var(--color-text);
+  margin-bottom: var(--space-1);
+}
+
+.recipeMeta {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.checkmark {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: var(--text-small);
+  color: var(--color-text-inverse);
+  flex-shrink: 0;
+}
+
+/* ── Category Pill ────────────────────────────────────────────────────── */
+
+.categoryPill {
+  font: var(--text-badge);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+}
+
+.categoryMain { color: var(--color-primary); background: var(--color-primary-bg); }
+.categorySide { color: var(--color-success); background: var(--color-success-bg); }
+.categorySnack { color: var(--color-warning); background: var(--color-warning-bg); }
+.categoryDessert { color: var(--color-fat); background: var(--color-fat-bg); }
+.categoryBreakfast { color: var(--color-carbs); background: var(--color-carbs-bg); }
+.categoryDefault { color: var(--color-text-muted); background: var(--color-surface-hover); }
+
+/* ── Time Badge ───────────────────────────────────────────────────────── */
+
+.timeBadge {
+  font: var(--text-small);
+  color: var(--color-text-muted);
+}
+
+/* ── Tags ─────────────────────────────────────────────────────────────── */
+
+.tags {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-2);
+}
+
+.tag {
+  font: var(--text-badge);
+  color: var(--color-text-dim);
+  background: var(--color-surface-hover);
+  padding: var(--space-1) var(--space-1);
+  border-radius: var(--radius-pill);
+}
+
+/* ── Macros row ───────────────────────────────────────────────────────── */
+
+.macros {
+  margin-top: var(--space-2);
+}
+
+/* ── Empty State ──────────────────────────────────────────────────────── */
+
+.empty {
+  text-align: center;
+  padding: var(--space-5);
+  color: var(--color-text-muted);
+}
+
+/* ── Sticky Footer ────────────────────────────────────────────────────── */
+
+.footer {
+  margin-top: var(--space-5);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  position: sticky;
+  bottom: var(--space-4);
+  background: var(--color-bg);
+  padding: var(--space-3) 0;
+}

--- a/frontend/src/pages/RecipeSelectorPage.module.css
+++ b/frontend/src/pages/RecipeSelectorPage.module.css
@@ -29,19 +29,11 @@
   gap: var(--space-3);
 }
 
-/* ── Recipe Card ──────────────────────────────────────────────────────── */
-
-.recipeCardHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: var(--space-2);
-}
+/* ── Recipe Card content ─────────────────────────────────────────────── */
 
 .recipeName {
   font: var(--text-label);
   color: var(--color-text);
-  margin-bottom: var(--space-1);
 }
 
 .recipeMeta {
@@ -51,8 +43,8 @@
 }
 
 .checkmark {
-  width: 24px;
-  height: 24px;
+  width: var(--space-4);
+  height: var(--space-4);
   border-radius: var(--radius-pill);
   background: var(--color-primary);
   display: flex;
@@ -102,12 +94,6 @@
   background: var(--color-surface-hover);
   padding: var(--space-1) var(--space-1);
   border-radius: var(--radius-pill);
-}
-
-/* ── Macros row ───────────────────────────────────────────────────────── */
-
-.macros {
-  margin-top: var(--space-2);
 }
 
 /* ── Empty State ──────────────────────────────────────────────────────── */

--- a/frontend/src/pages/RecipeSelectorPage.tsx
+++ b/frontend/src/pages/RecipeSelectorPage.tsx
@@ -1,0 +1,200 @@
+import { useState, useMemo, useEffect } from "react";
+import { Button, Card, MacroBadgeRow } from "../components";
+import type { RecipeHit } from "../types.ts";
+import { fetchRecipes } from "../api.ts";
+import styles from "./RecipeSelectorPage.module.css";
+
+/* ── Category Pill ────────────────────────────────────────────────────── */
+
+const CATEGORY_CLASS: Record<string, string> = {
+  main: styles.categoryMain ?? "",
+  side: styles.categorySide ?? "",
+  snack: styles.categorySnack ?? "",
+  dessert: styles.categoryDessert ?? "",
+  breakfast: styles.categoryBreakfast ?? "",
+};
+
+function CategoryPill({ category }: { category: string | null }) {
+  if (!category) return null;
+  const colorClass = CATEGORY_CLASS[category] ?? styles.categoryDefault;
+
+  return (
+    <span className={`${styles.categoryPill} ${colorClass}`}>
+      {category}
+    </span>
+  );
+}
+
+/* ── Time Badge ───────────────────────────────────────────────────────── */
+
+function TimeBadge({
+  prepMinutes,
+  cookMinutes,
+}: {
+  prepMinutes: number | null;
+  cookMinutes: number | null;
+}) {
+  const total = (prepMinutes ?? 0) + (cookMinutes ?? 0);
+  if (total === 0) return null;
+
+  return (
+    <span className={styles.timeBadge}>
+      {"\u23F1"} {total} min
+    </span>
+  );
+}
+
+/* ── Recipe Card ──────────────────────────────────────────────────────── */
+
+function RecipeCard({
+  recipe,
+  isSelected,
+  onSelect,
+}: {
+  recipe: RecipeHit;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <Card
+      onClick={() => onSelect(recipe.id)}
+      selected={isSelected}
+    >
+      <div className={styles.recipeCardHeader}>
+        <div>
+          <h3 className={styles.recipeName}>{recipe.name}</h3>
+          <div className={styles.recipeMeta}>
+            <CategoryPill category={recipe.category} />
+            <TimeBadge prepMinutes={recipe.prep_minutes} cookMinutes={recipe.cook_minutes} />
+          </div>
+        </div>
+        {isSelected && (
+          <div className={styles.checkmark}>{"\u2713"}</div>
+        )}
+      </div>
+
+      {recipe.tags.length > 0 && (
+        <div className={styles.tags}>
+          {recipe.tags.slice(0, 4).map((tag) => (
+            <span key={tag} className={styles.tag}>{tag}</span>
+          ))}
+        </div>
+      )}
+
+      {recipe.macro_summary && (
+        <MacroBadgeRow macros={recipe.macro_summary} className={styles.macros} />
+      )}
+    </Card>
+  );
+}
+
+/* ── Filter Bar ───────────────────────────────────────────────────────── */
+
+function FilterBar({
+  categories,
+  selected,
+  onChange,
+}: {
+  categories: string[];
+  selected: string | null;
+  onChange: (cat: string | null) => void;
+}) {
+  return (
+    <div className={styles.filterBar}>
+      <Button
+        variant={!selected ? "primary" : "secondary"}
+        size="sm"
+        onPress={() => onChange(null)}
+      >
+        All
+      </Button>
+      {categories.map((cat) => (
+        <Button
+          key={cat}
+          variant={selected === cat ? "primary" : "secondary"}
+          size="sm"
+          onPress={() => onChange(cat)}
+        >
+          {cat.charAt(0).toUpperCase() + cat.slice(1)}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+/* ── Page Component ──────────────────────────────────────────────────── */
+
+export function RecipeSelectorPage() {
+  const [recipes, setRecipes] = useState<RecipeHit[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchRecipes()
+      .then(setRecipes)
+      .catch(() => { /* API unavailable */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const categories = useMemo(() => {
+    const cats = new Set(recipes.map((r) => r.category).filter(Boolean) as string[]);
+    return [...cats].sort();
+  }, [recipes]);
+
+  const filtered = useMemo(
+    () => (categoryFilter ? recipes.filter((r) => r.category === categoryFilter) : recipes),
+    [recipes, categoryFilter],
+  );
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading recipes...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className="view-header">
+        <h1>Select a Recipe</h1>
+        <p>
+          {recipes.length} recipe{recipes.length !== 1 ? "s" : ""} found — tap to select.
+        </p>
+      </div>
+
+      {categories.length > 1 && (
+        <FilterBar categories={categories} selected={categoryFilter} onChange={setCategoryFilter} />
+      )}
+
+      <div className={styles.recipeGrid}>
+        {filtered.map((recipe) => (
+          <RecipeCard
+            key={recipe.id}
+            recipe={recipe}
+            isSelected={selectedId === recipe.id}
+            onSelect={setSelectedId}
+          />
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className={styles.empty}>
+          {recipes.length === 0
+            ? "No recipes available. Add some recipes to get started."
+            : "No recipes match the current filter."}
+        </div>
+      )}
+
+      <div className={styles.footer}>
+        <Button variant="secondary" onPress={() => setSelectedId(null)}>
+          Clear
+        </Button>
+        <Button isDisabled={!selectedId}>
+          View Recipe Details
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/RecipeSelectorPage.tsx
+++ b/frontend/src/pages/RecipeSelectorPage.tsx
@@ -59,32 +59,29 @@ function RecipeCard({
     <Card
       onClick={() => onSelect(recipe.id)}
       selected={isSelected}
-    >
-      <div className={styles.recipeCardHeader}>
-        <div>
-          <h3 className={styles.recipeName}>{recipe.name}</h3>
-          <div className={styles.recipeMeta}>
-            <CategoryPill category={recipe.category} />
-            <TimeBadge prepMinutes={recipe.prep_minutes} cookMinutes={recipe.cook_minutes} />
-          </div>
+      pretitle={
+        <div className={styles.recipeMeta}>
+          <CategoryPill category={recipe.category} />
+          <TimeBadge prepMinutes={recipe.prep_minutes} cookMinutes={recipe.cook_minutes} />
         </div>
-        {isSelected && (
-          <div className={styles.checkmark}>{"\u2713"}</div>
-        )}
-      </div>
-
-      {recipe.tags.length > 0 && (
-        <div className={styles.tags}>
-          {recipe.tags.slice(0, 4).map((tag) => (
-            <span key={tag} className={styles.tag}>{tag}</span>
-          ))}
-        </div>
-      )}
-
-      {recipe.macro_summary && (
-        <MacroBadgeRow macros={recipe.macro_summary} className={styles.macros} />
-      )}
-    </Card>
+      }
+      title={<span className={styles.recipeName}>{recipe.name}</span>}
+      trailingMedia={isSelected ? <div className={styles.checkmark}>{"\u2713"}</div> : undefined}
+      body={
+        <>
+          {recipe.tags.length > 0 && (
+            <div className={styles.tags}>
+              {recipe.tags.slice(0, 4).map((tag) => (
+                <span key={tag} className={styles.tag}>{tag}</span>
+              ))}
+            </div>
+          )}
+          {recipe.macro_summary && (
+            <MacroBadgeRow macros={recipe.macro_summary} />
+          )}
+        </>
+      }
+    />
   );
 }
 

--- a/frontend/src/pages/WeeklyCalendarPage.module.css
+++ b/frontend/src/pages/WeeklyCalendarPage.module.css
@@ -29,33 +29,25 @@
   margin-bottom: var(--space-5);
 }
 
-/* ── Day Column ───────────────────────────────────────────────────────── */
-
-.dayColumn {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-none);
-  padding: var(--space-3);
-  min-height: 280px;
-  display: flex;
-  flex-direction: column;
-}
+/* ── Day Column (Card overrides) ─────────────────────────────────────── */
 
 .dayColumnFilled {
   box-shadow: inset 0 0 0 1px var(--color-border);
 }
 
-.dayName {
-  font: var(--text-label);
-  color: var(--color-text);
-  margin-bottom: var(--space-2);
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid var(--color-border);
+.dayContent {
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
 }
 
 .dayMeals {
   flex: 1;
   margin-bottom: var(--space-2);
+}
+
+.dayVariance {
+  margin-top: auto;
 }
 
 .dayEmpty {
@@ -132,12 +124,6 @@
 
 .summaryCard {
   margin-bottom: var(--space-4);
-}
-
-.summaryLabel {
-  font: var(--text-small-semibold);
-  color: var(--color-text-muted);
-  margin-bottom: var(--space-2);
 }
 
 .summaryGrid {

--- a/frontend/src/pages/WeeklyCalendarPage.module.css
+++ b/frontend/src/pages/WeeklyCalendarPage.module.css
@@ -1,0 +1,147 @@
+/* ── WeeklyCalendarPage ──────────────────────────────────────────────── */
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.loading {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+  font: var(--text-body);
+}
+
+/* ── Plan Selector ───────────────────────────────────────────────────── */
+
+.planSelector {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+/* ── Day Grid ─────────────────────────────────────────────────────────── */
+
+.dayGrid {
+  display: grid;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+
+/* ── Day Column ───────────────────────────────────────────────────────── */
+
+.dayColumn {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-none);
+  padding: var(--space-3);
+  min-height: 280px;
+  display: flex;
+  flex-direction: column;
+}
+
+.dayColumnFilled {
+  box-shadow: inset 0 0 0 1px var(--color-border);
+}
+
+.dayName {
+  font: var(--text-label);
+  color: var(--color-text);
+  margin-bottom: var(--space-2);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.dayMeals {
+  flex: 1;
+  margin-bottom: var(--space-2);
+}
+
+.dayEmpty {
+  color: var(--color-text-dim);
+  font: var(--text-small);
+  text-align: center;
+  padding: var(--space-4);
+}
+
+/* ── Meal Chip ────────────────────────────────────────────────────────── */
+
+.mealChip {
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-none);
+  margin-bottom: var(--space-1);
+}
+
+.mealChipBreakfast { background: var(--color-chip-breakfast); border-left: 3px solid var(--color-carbs); }
+.mealChipLunch { background: var(--color-chip-lunch); border-left: 3px solid var(--color-protein); }
+.mealChipDinner { background: var(--color-chip-dinner); border-left: 3px solid var(--color-primary); }
+.mealChipSnack { background: var(--color-chip-snack); border-left: 3px solid var(--color-text-muted); }
+
+.mealType {
+  font: var(--text-badge);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-1);
+}
+
+.mealTypeBreakfast { color: var(--color-carbs); }
+.mealTypeLunch { color: var(--color-protein); }
+.mealTypeDinner { color: var(--color-primary); }
+.mealTypeSnack { color: var(--color-text-muted); }
+
+.mealRecipe {
+  font: var(--text-small);
+  color: var(--color-text);
+  line-height: 20px;
+}
+
+/* ── Macro Variance Bar ───────────────────────────────────────────────── */
+
+.varianceBar {
+  margin-bottom: var(--space-1);
+}
+
+.varianceHeader {
+  display: flex;
+  justify-content: space-between;
+  font: var(--text-badge);
+  color: var(--color-text-dim);
+  margin-bottom: var(--space-1);
+}
+
+.varianceValue {
+  font-weight: 600;
+}
+
+.varianceTrack {
+  height: var(--space-1);
+  background: var(--color-border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.varianceFill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  transition: width 0.3s ease;
+  width: var(--progress-pct);
+}
+
+/* ── Weekly Summary ───────────────────────────────────────────────────── */
+
+.summaryCard {
+  margin-bottom: var(--space-4);
+}
+
+.summaryLabel {
+  font: var(--text-small-semibold);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+}

--- a/frontend/src/pages/WeeklyCalendarPage.tsx
+++ b/frontend/src/pages/WeeklyCalendarPage.tsx
@@ -139,34 +139,33 @@ function DayColumn({
   const firstMemberMacros = Object.values(macros)[0];
   const isEmpty = Object.keys(meals).length === 0;
 
-  const columnClasses = [
-    styles.dayColumn,
-    !isEmpty ? styles.dayColumnFilled : "",
-  ].filter(Boolean).join(" ");
-
   return (
-    <div className={columnClasses}>
-      <div className={styles.dayName}>{dayName}</div>
+    <Card
+      pretitle={dayName}
+      body={
+        <div className={styles.dayContent}>
+          <div className={styles.dayMeals}>
+            {isEmpty ? (
+              <div className={styles.dayEmpty}>No meals</div>
+            ) : (
+              MEAL_ORDER.filter((mt) => meals[mt] && meals[mt].length > 0).map((mt) => (
+                <MealChip key={mt} mealType={mt} recipes={meals[mt]!} />
+              ))
+            )}
+          </div>
 
-      <div className={styles.dayMeals}>
-        {isEmpty ? (
-          <div className={styles.dayEmpty}>No meals</div>
-        ) : (
-          MEAL_ORDER.filter((mt) => meals[mt] && meals[mt].length > 0).map((mt) => (
-            <MealChip key={mt} mealType={mt} recipes={meals[mt]!} />
-          ))
-        )}
-      </div>
-
-      {targets && firstMemberMacros?.calories != null && (
-        <div>
-          <MacroVarianceBar actual={firstMemberMacros.calories} target={targets.calories} nutrient="Cal" macro="calories" />
-          <MacroVarianceBar actual={firstMemberMacros.protein_g} target={targets.protein_g} nutrient="Protein" macro="protein" />
-          <MacroVarianceBar actual={firstMemberMacros.carbs_g} target={targets.carbs_g} nutrient="Carbs" macro="carbs" />
-          <MacroVarianceBar actual={firstMemberMacros.fat_g} target={targets.fat_g} nutrient="Fat" macro="fat" />
+          {targets && firstMemberMacros?.calories != null && (
+            <div className={styles.dayVariance}>
+              <MacroVarianceBar actual={firstMemberMacros.calories} target={targets.calories} nutrient="Cal" macro="calories" />
+              <MacroVarianceBar actual={firstMemberMacros.protein_g} target={targets.protein_g} nutrient="Protein" macro="protein" />
+              <MacroVarianceBar actual={firstMemberMacros.carbs_g} target={targets.carbs_g} nutrient="Carbs" macro="carbs" />
+              <MacroVarianceBar actual={firstMemberMacros.fat_g} target={targets.fat_g} nutrient="Fat" macro="fat" />
+            </div>
+          )}
         </div>
-      )}
-    </div>
+      }
+      className={!isEmpty ? styles.dayColumnFilled : undefined}
+    />
   );
 }
 
@@ -183,15 +182,18 @@ function WeeklySummary({
   if (!avg) return null;
 
   return (
-    <Card className={styles.summaryCard}>
-      <div className={styles.summaryLabel}>Weekly Average</div>
-      <div className={styles.summaryGrid}>
-        <ProgressBar value={avg.calories} max={targets?.calories ?? avg.calories} macro="calories" label="Calories" />
-        <ProgressBar value={avg.protein_g} max={targets?.protein_g ?? avg.protein_g} macro="protein" label="Protein" />
-        <ProgressBar value={avg.carbs_g} max={targets?.carbs_g ?? avg.carbs_g} macro="carbs" label="Carbs" />
-        <ProgressBar value={avg.fat_g} max={targets?.fat_g ?? avg.fat_g} macro="fat" label="Fat" />
-      </div>
-    </Card>
+    <Card
+      pretitle="Weekly Average"
+      body={
+        <div className={styles.summaryGrid}>
+          <ProgressBar value={avg.calories} max={targets?.calories ?? avg.calories} macro="calories" label="Calories" />
+          <ProgressBar value={avg.protein_g} max={targets?.protein_g ?? avg.protein_g} macro="protein" label="Protein" />
+          <ProgressBar value={avg.carbs_g} max={targets?.carbs_g ?? avg.carbs_g} macro="carbs" label="Carbs" />
+          <ProgressBar value={avg.fat_g} max={targets?.fat_g ?? avg.fat_g} macro="fat" label="Fat" />
+        </div>
+      }
+      className={styles.summaryCard}
+    />
   );
 }
 

--- a/frontend/src/pages/WeeklyCalendarPage.tsx
+++ b/frontend/src/pages/WeeklyCalendarPage.tsx
@@ -1,0 +1,306 @@
+import { useState, useMemo, useEffect } from "react";
+import { Button, Card, ProgressBar } from "../components";
+import type { DaySummary, MacroSummary, MealComponent, PlanSummary } from "../types.ts";
+import { fetchPlans, fetchPlanSummary, fetchMacroTargets } from "../api.ts";
+import styles from "./WeeklyCalendarPage.module.css";
+
+const DAY_SHORT = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MEAL_ORDER = ["breakfast", "lunch", "dinner", "snack"] as const;
+
+/* ── Plan Selector ───────────────────────────────────────────────────── */
+
+interface PlanOption {
+  id: string;
+  name: string;
+}
+
+function PlanSelector({
+  plans,
+  selectedId,
+  onSelect,
+}: {
+  plans: PlanOption[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  if (plans.length === 0) return null;
+
+  return (
+    <div className={styles.planSelector}>
+      {plans.map((plan) => (
+        <Button
+          key={plan.id}
+          variant={selectedId === plan.id ? "primary" : "secondary"}
+          size="sm"
+          onPress={() => onSelect(plan.id)}
+        >
+          {plan.name}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+/* ── Macro Variance Bar ───────────────────────────────────────────────── */
+
+function MacroVarianceBar({
+  actual,
+  target,
+  nutrient,
+  macro,
+}: {
+  actual: number;
+  target: number;
+  nutrient: string;
+  macro: "protein" | "carbs" | "fat" | "calories";
+}) {
+  if (target === 0) return null;
+  const pct = (actual / target) * 100;
+  const isOver = pct > 105;
+  const isUnder = pct < 85;
+
+  const fillColor = isOver
+    ? "var(--color-danger)"
+    : isUnder
+      ? "var(--color-warning)"
+      : `var(--color-${macro})`;
+
+  return (
+    <div className={styles.varianceBar}>
+      <div className={styles.varianceHeader}>
+        <span>{nutrient}</span>
+        <span
+          className={styles.varianceValue}
+          {...{ style: { color: fillColor } as React.CSSProperties }}
+        >
+          {Math.round(actual)}/{Math.round(target)}
+        </span>
+      </div>
+      <div className={styles.varianceTrack}>
+        <div
+          className={styles.varianceFill}
+          {...{
+            style: {
+              "--progress-pct": `${Math.min(pct, 100)}%`,
+              background: fillColor,
+            } as React.CSSProperties,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ── Meal Chip ────────────────────────────────────────────────────────── */
+
+const CHIP_CLASS: Record<string, string> = {
+  breakfast: styles.mealChipBreakfast ?? "",
+  lunch: styles.mealChipLunch ?? "",
+  dinner: styles.mealChipDinner ?? "",
+  snack: styles.mealChipSnack ?? "",
+};
+
+const TYPE_CLASS: Record<string, string> = {
+  breakfast: styles.mealTypeBreakfast ?? "",
+  lunch: styles.mealTypeLunch ?? "",
+  dinner: styles.mealTypeDinner ?? "",
+  snack: styles.mealTypeSnack ?? "",
+};
+
+function MealChip({ mealType, recipes }: { mealType: string; recipes: MealComponent[] }) {
+  return (
+    <div className={`${styles.mealChip} ${CHIP_CLASS[mealType] ?? ""}`}>
+      <div className={`${styles.mealType} ${TYPE_CLASS[mealType] ?? ""}`}>
+        {mealType}
+      </div>
+      {recipes.map((r, i) => (
+        <div key={i} className={styles.mealRecipe}>
+          {r.recipe_name ?? r.recipe_id}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Day Column ───────────────────────────────────────────────────────── */
+
+function DayColumn({
+  dayOffset,
+  dayData,
+  targets,
+}: {
+  dayOffset: number;
+  dayData: DaySummary;
+  targets: MacroSummary | null;
+}) {
+  const dayName = DAY_SHORT[dayOffset % 7] ?? `Day ${dayOffset + 1}`;
+  const meals = dayData.meals ?? {};
+  const macros = dayData.member_macros ?? {};
+  const firstMemberMacros = Object.values(macros)[0];
+  const isEmpty = Object.keys(meals).length === 0;
+
+  const columnClasses = [
+    styles.dayColumn,
+    !isEmpty ? styles.dayColumnFilled : "",
+  ].filter(Boolean).join(" ");
+
+  return (
+    <div className={columnClasses}>
+      <div className={styles.dayName}>{dayName}</div>
+
+      <div className={styles.dayMeals}>
+        {isEmpty ? (
+          <div className={styles.dayEmpty}>No meals</div>
+        ) : (
+          MEAL_ORDER.filter((mt) => meals[mt] && meals[mt].length > 0).map((mt) => (
+            <MealChip key={mt} mealType={mt} recipes={meals[mt]!} />
+          ))
+        )}
+      </div>
+
+      {targets && firstMemberMacros?.calories != null && (
+        <div>
+          <MacroVarianceBar actual={firstMemberMacros.calories} target={targets.calories} nutrient="Cal" macro="calories" />
+          <MacroVarianceBar actual={firstMemberMacros.protein_g} target={targets.protein_g} nutrient="Protein" macro="protein" />
+          <MacroVarianceBar actual={firstMemberMacros.carbs_g} target={targets.carbs_g} nutrient="Carbs" macro="carbs" />
+          <MacroVarianceBar actual={firstMemberMacros.fat_g} target={targets.fat_g} nutrient="Fat" macro="fat" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Weekly Summary ───────────────────────────────────────────────────── */
+
+function WeeklySummary({
+  weeklyAverages,
+  targets,
+}: {
+  weeklyAverages: Record<string, MacroSummary>;
+  targets: MacroSummary | null;
+}) {
+  const avg = Object.values(weeklyAverages)[0];
+  if (!avg) return null;
+
+  return (
+    <Card className={styles.summaryCard}>
+      <div className={styles.summaryLabel}>Weekly Average</div>
+      <div className={styles.summaryGrid}>
+        <ProgressBar value={avg.calories} max={targets?.calories ?? avg.calories} macro="calories" label="Calories" />
+        <ProgressBar value={avg.protein_g} max={targets?.protein_g ?? avg.protein_g} macro="protein" label="Protein" />
+        <ProgressBar value={avg.carbs_g} max={targets?.carbs_g ?? avg.carbs_g} macro="carbs" label="Carbs" />
+        <ProgressBar value={avg.fat_g} max={targets?.fat_g ?? avg.fat_g} macro="fat" label="Fat" />
+      </div>
+    </Card>
+  );
+}
+
+/* ── Page Component ──────────────────────────────────────────────────── */
+
+interface WeeklyCalendarPageProps {
+  memberId?: string;
+}
+
+export function WeeklyCalendarPage({ memberId }: WeeklyCalendarPageProps) {
+  const [plans, setPlans] = useState<PlanOption[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const [planSummary, setPlanSummary] = useState<PlanSummary | null>(null);
+  const [targets, setTargets] = useState<MacroSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchPlans()
+      .then((result) => {
+        const options = result.map((p) => ({ id: p.id, name: p.name }));
+        setPlans(options);
+        if (options.length > 0) {
+          setSelectedPlanId(options[0]!.id);
+        }
+      })
+      .catch(() => { /* API unavailable */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedPlanId) return;
+    setLoading(true);
+    fetchPlanSummary(selectedPlanId, memberId)
+      .then(setPlanSummary)
+      .catch(() => setPlanSummary(null))
+      .finally(() => setLoading(false));
+  }, [selectedPlanId, memberId]);
+
+  useEffect(() => {
+    if (!memberId) return;
+    fetchMacroTargets(memberId)
+      .then((tgts) => {
+        const active = tgts.find((t) => t.is_active);
+        if (active) {
+          setTargets({
+            calories: active.calories,
+            protein_g: active.protein_g,
+            carbs_g: active.carbs_g,
+            fat_g: active.fat_g,
+          });
+        }
+      })
+      .catch(() => { /* ignore */ });
+  }, [memberId]);
+
+  const days = useMemo(() => {
+    if (!planSummary) return [];
+    const dayMap: Record<number, DaySummary> = {};
+    for (const ds of planSummary.daily_summaries) {
+      dayMap[ds.day_offset] = ds;
+    }
+    return Array.from({ length: planSummary.days }, (_, i) =>
+      dayMap[i] ?? { day_offset: i, meals: {}, member_macros: {} },
+    );
+  }, [planSummary]);
+
+  if (loading && !planSummary) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.loading}>Loading meal plans...</div>
+      </div>
+    );
+  }
+
+  if (plans.length === 0) {
+    return (
+      <div className={styles.container}>
+        <div className="view-header">
+          <h1>Weekly Calendar</h1>
+          <p>No meal plans found. Create one to get started.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const gridStyle = planSummary
+    ? { gridTemplateColumns: `repeat(${Math.min(planSummary.days, 7)}, 1fr)` } as React.CSSProperties
+    : undefined;
+
+  return (
+    <div className={styles.container}>
+      <div className="view-header">
+        <h1>{planSummary?.plan_name ?? "Weekly Calendar"}</h1>
+        <p>{planSummary ? `${planSummary.days}-day plan overview` : "Select a plan"}</p>
+      </div>
+
+      <PlanSelector plans={plans} selectedId={selectedPlanId} onSelect={setSelectedPlanId} />
+
+      {planSummary && (
+        <>
+          <WeeklySummary weeklyAverages={planSummary.weekly_averages} targets={targets} />
+
+          <div className={styles.dayGrid} {...(gridStyle ? { style: gridStyle } : {})}>
+            {days.map((day) => (
+              <DayColumn key={day.day_offset} dayOffset={day.day_offset} dayData={day} targets={targets} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,0 +1,4 @@
+export { MacroSetterPage } from "./MacroSetterPage";
+export { RecipeSelectorPage } from "./RecipeSelectorPage";
+export { WeeklyCalendarPage } from "./WeeklyCalendarPage";
+export { GroceryListPage } from "./GroceryListPage";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     emptyOutDir: true,
     rollupOptions: {
       input: {
+        "app": resolve(__dirname, "app.html"),
         "macro-setter": resolve(__dirname, "macro-setter.html"),
         "recipe-selector": resolve(__dirname, "recipe-selector.html"),
         "weekly-calendar": resolve(__dirname, "weekly-calendar.html"),


### PR DESCRIPTION
## Summary

- Adds a unified SPA frontend so users can access the full app via web browser without using MCP tokens
- Builds an AppShell layout with collapsible sidebar (SVG nav icons + labels), top bar (logo + "Yes Chef" branding + Sign In placeholder), and centered content area
- Extracts existing MCP view logic into reusable page components (MacroSetter, RecipeSelector, WeeklyCalendar, GroceryList) that fetch data from `/api` REST routes
- Adds `api.ts` typed fetch utility for all REST endpoints
- Existing MCP standalone entries remain untouched and fully functional
- Vite builds all 5 entry points (4 MCP + 1 SPA) — typecheck and build pass cleanly

## Architecture

- **Routing**: Simple `useState<Page>` — no new dependencies for 4 pages
- **Sidebar**: Collapsible rail (64px collapsed / 200px expanded) with hamburger toggle
- **Data**: Pages fetch from existing `/api/*` FastAPI routes instead of MCP bridge
- **Styling**: CSS Modules + design tokens, React Aria Components, 8-point grid — all per CLAUDE.md rules

## New files

| File | Purpose |
|------|---------|
| `frontend/src/api.ts` | Typed fetch wrappers for REST API |
| `frontend/src/pages/*Page.tsx` | 4 SPA page components |
| `frontend/src/components/Sidebar/` | Collapsible nav sidebar with SVG icons |
| `frontend/src/components/TopBar/` | Top bar with logo, branding, sign-in |
| `frontend/src/components/AppShell/` | Layout shell composing TopBar + Sidebar + content |
| `frontend/src/entries/app.tsx` | SPA entry with useState routing |
| `frontend/app.html` | SPA HTML entry point |
| `backend/.../api/views.py` | Added `GET /api/views/app` route |

## Test plan

- [ ] `cd frontend && npm run typecheck` — passes with no errors
- [ ] `cd frontend && npm run build` — builds all 5 entries successfully
- [ ] Navigate to `/api/views/app` — SPA loads with sidebar + top bar
- [ ] Click each sidebar nav item — pages render correctly
- [ ] Toggle sidebar collapse/expand via hamburger
- [ ] Existing MCP views (`/api/views/macro-setter`, etc.) still work independently

https://claude.ai/code/session_0166Cb1GkYnaqwXVw6W4ZrM3