### PR TITLE
feat(backend): improve static asset serving and hybrid search robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 
 ## Configuration
 
-- **Database path**: defaults to `/data/yes_chef_mcp.db`, configurable via `configure_database()` in `core/db.py`
+- **Database path**: defaults to `data/yes_chef_mcp.db`, configurable via `YES_CHEF_DB_PATH` env var or `configure_db_path()` in `core/db.py`
 - **Nutrition APIs** (optional): USDA FoodData Central and Nutritionix keys are passed to `NutritionEnricher` at construction time
 
 ## Development

--- a/backend/yes_chef_mcp/api/views.py
+++ b/backend/yes_chef_mcp/api/views.py
@@ -23,17 +23,33 @@ from yes_chef_mcp.mcp.server import (
 # Vite build output lives in frontend/dist/ at the repo root (sibling of backend/)
 DIST_DIR = Path(__file__).parents[3] / "frontend" / "dist"
 
+# In development, we might be viewed through a proxy (like MCP Inspector)
+# on a different port. This base URL ensures assets still load from FastAPI.
+BASE_URL = "http://localhost:8000/"
+
 router = APIRouter(tags=["views"])
 
 
-def _inject_data(html_path: Path, data: dict[str, object]) -> str:
-    """Read an HTML file and inject JSON data into the <script id="view-data"> tag."""
+def prepare_html(html_path: Path, data: dict[str, object] | None = None) -> str:
+    """Read HTML, inject JSON data, and rewrite asset paths to absolute URLs."""
+    if not html_path.exists():
+        return f"<html><body><h1>View not found: {html_path.name}</h1><p>Path: {html_path}</p></body></html>"
+
     html = html_path.read_text()
-    data_json = json.dumps(data, default=str)
-    html = html.replace(
-        '<script id="view-data" type="application/json">{}</script>',
-        f'<script id="view-data" type="application/json">{data_json}</script>',
-    )
+
+    # 1. Rewrite relative asset paths to absolute FastAPI URLs
+    # This is more robust than <base> in some sandboxed environments (like MCP clients)
+    html = html.replace('src="/views/static/', f'src="{BASE_URL}views/static/')
+    html = html.replace('href="/views/static/', f'href="{BASE_URL}views/static/')
+
+    # 2. Inject data if provided
+    if data is not None:
+        data_json = json.dumps(data, default=str)
+        html = html.replace(
+            '<script id="view-data" type="application/json">{}</script>',
+            f'<script id="view-data" type="application/json">{data_json}</script>',
+        )
+
     return html
 
 
@@ -53,7 +69,7 @@ async def macro_setter_view(member_id: str | None = None) -> HTMLResponse:
             "name": active.name,
         }
 
-    html = _inject_data(DIST_DIR / "macro-setter.html", data)
+    html = prepare_html(DIST_DIR / "macro-setter.html", data)
     return HTMLResponse(content=html)
 
 
@@ -92,7 +108,7 @@ async def recipe_selector_view(
         for hit in result.hits
     ]
 
-    html = _inject_data(DIST_DIR / "recipe-selector.html", {"recipes": recipes})
+    html = prepare_html(DIST_DIR / "recipe-selector.html", {"recipes": recipes})
     return HTMLResponse(content=html)
 
 
@@ -120,7 +136,7 @@ async def weekly_calendar_view(
     if targets:
         data["targets"] = targets
 
-    html = _inject_data(DIST_DIR / "weekly-calendar.html", data)
+    html = prepare_html(DIST_DIR / "weekly-calendar.html", data)
     return HTMLResponse(content=html)
 
 
@@ -134,5 +150,6 @@ async def grocery_list_view(
     grocery = await generate_grocery_list(plan_id, merge_similar, exclude_pantry)
 
     data: dict[str, object] = {"grocery_list": grocery.model_dump()}
-    html = _inject_data(DIST_DIR / "grocery-list.html", data)
+    html = prepare_html(DIST_DIR / "grocery-list.html", data)
     return HTMLResponse(content=html)
+

--- a/backend/yes_chef_mcp/app.py
+++ b/backend/yes_chef_mcp/app.py
@@ -11,7 +11,9 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.responses import Response
 
 from yes_chef_mcp.api.routes import router
 from yes_chef_mcp.api.views import DIST_DIR
@@ -46,14 +48,31 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Enable CORS for development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+    expose_headers=["*"],
+)
+
 # REST API routes
 app.include_router(router, prefix="/api")
 
 # HTML view components (served at /api/views/*)
 app.include_router(views_router, prefix="/api")
 
-# Vite build output — JS/CSS bundles referenced by the HTML views
-app.mount("/views/static", StaticFiles(directory=str(DIST_DIR)), name="view-static")
+
+# Vite build output — served via a regular route so CORS middleware applies.
+# (StaticFiles mounted via app.mount() bypasses middleware in Starlette 0.40+)
+@app.get("/views/static/{path:path}", include_in_schema=False)
+async def serve_static(path: str) -> Response:
+    file_path = DIST_DIR / path
+    if not file_path.exists() or not file_path.is_file():
+        return Response(status_code=404)
+    return FileResponse(file_path)
+
 
 # Mount FastMCP's HTTP transport at /mcp
 app.mount("/mcp", mcp_app)

--- a/backend/yes_chef_mcp/core/search.py
+++ b/backend/yes_chef_mcp/core/search.py
@@ -25,8 +25,43 @@ def _rrf_score(rank: int, k: int = 60) -> float:
     return 1.0 / (k + rank)
 
 
+def _sanitize_fts_query(query: str) -> str | None:
+    """Sanitize a query for FTS5. Returns None if the result is empty."""
+    clean = query.strip()
+    if not clean:
+        return None
+    for char in "*:-":
+        clean = clean.replace(char, " ")
+    return clean.strip() or None
+
+
+def _build_hit(
+    row: dict[str, str | int | float | None],
+    macro_summary: MacroSummary,
+    search_score: float,
+    match_type: MatchType,
+) -> RecipeSearchHit:
+    tags: list[str] = json.loads(str(row.get("tags", "[]")))
+    cat_val = row.get("category")
+    return RecipeSearchHit(
+        id=str(row["id"]),
+        name=str(row["name"]),
+        category=RecipeCategory(str(cat_val)) if cat_val else None,
+        tags=tags,
+        prep_minutes=int(str(row["prep_minutes"])) if row.get("prep_minutes") is not None else None,
+        cook_minutes=int(str(row["cook_minutes"])) if row.get("cook_minutes") is not None else None,
+        macro_summary=macro_summary,
+        search_score=search_score,
+        match_type=match_type,
+    )
+
+
 async def _fts_search(query: str, limit: int) -> list[tuple[str, float]]:
     """Full-text search returning (recipe_id, rank) pairs."""
+    clean_query = _sanitize_fts_query(query)
+    if clean_query is None:
+        return []
+
     async with get_db() as db, db.execute(
         """
             SELECT recipe_id, rank
@@ -35,7 +70,7 @@ async def _fts_search(query: str, limit: int) -> list[tuple[str, float]]:
             ORDER BY rank
             LIMIT ?
             """,
-        (query, limit),
+        (clean_query, limit),
     ) as cursor:
         rows = await cursor.fetchall()
         return [(str(row["recipe_id"]), float(str(row["rank"]))) for row in rows]
@@ -77,6 +112,36 @@ async def _fetch_recipe_metadata(
     return {str(row["id"]): dict(row) for row in rows}
 
 
+async def _browse_recipe_ids(
+    category: RecipeCategory | None,
+    tags: list[str] | None,
+    limit: int,
+) -> list[str]:
+    """Fetch recipe IDs for browse (no-query) mode with optional filters."""
+    conditions: list[str] = []
+    params: list[str] = []
+
+    if category:
+        conditions.append("category = ?")
+        params.append(category.value)
+
+    if tags:
+        placeholders = ",".join("?" for _ in tags)
+        conditions.append(
+            f"EXISTS (SELECT 1 FROM json_each(tags) AS jt WHERE jt.value IN ({placeholders}))"
+        )
+        params.extend(tags)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    async with get_db() as db, db.execute(
+        f"SELECT id FROM recipes {where} LIMIT ?",
+        [*params, limit],
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return [str(row["id"]) for row in rows]
+
+
 async def hybrid_search(
     query: str,
     embedding: list[float] | None = None,
@@ -92,37 +157,43 @@ async def hybrid_search(
     1. FTS5 keyword match on recipe name + ingredient names
     2. Vector similarity via sqlite-vec (if embedding provided)
     3. Reciprocal Rank Fusion merges both ranked lists
+    4. Falls back to browse-all when no query and no embedding
 
     Keyword matches are boosted so exact matches always rank first.
     """
     fetch_limit = max_results * 4  # Over-fetch for filtering
 
+    clean_query = _sanitize_fts_query(query)
+
     # FTS5 keyword search
-    fts_results = await _fts_search(query, fetch_limit)
+    fts_results = await _fts_search(query, fetch_limit) if clean_query is not None else []
     fts_ids = {rid for rid, _ in fts_results}
 
     # Vector similarity search (if embedding provided)
     vec_results: list[tuple[str, float]] = []
-    vec_ids: set[str] = set()
     if embedding:
         vec_results = await _vector_search(embedding, fetch_limit)
-        vec_ids = {rid for rid, _ in vec_results}
 
-    # Reciprocal Rank Fusion
     scores: dict[str, float] = {}
     match_types: dict[str, MatchType] = {}
 
-    # FTS results get a 2x boost for exact keyword relevance
-    for rank, (rid, _) in enumerate(fts_results):
-        scores[rid] = scores.get(rid, 0.0) + 2.0 * _rrf_score(rank)
-        match_types[rid] = MatchType.KEYWORD
+    if not fts_results and not vec_results:
+        # No query and no embedding — return all recipes (filtered downstream)
+        for rid in await _browse_recipe_ids(category, tags, fetch_limit):
+            scores[rid] = 1.0
+            match_types[rid] = MatchType.KEYWORD
+    else:
+        # Reciprocal Rank Fusion — FTS gets a 2x boost for exact keyword relevance
+        for rank, (rid, _) in enumerate(fts_results):
+            scores[rid] = scores.get(rid, 0.0) + 2.0 * _rrf_score(rank)
+            match_types[rid] = MatchType.KEYWORD
 
-    for rank, (rid, _) in enumerate(vec_results):
-        scores[rid] = scores.get(rid, 0.0) + _rrf_score(rank)
-        if rid in fts_ids:
-            match_types[rid] = MatchType.BOTH
-        elif rid not in match_types:
-            match_types[rid] = MatchType.SEMANTIC
+        for rank, (rid, _) in enumerate(vec_results):
+            scores[rid] = scores.get(rid, 0.0) + _rrf_score(rank)
+            if rid in fts_ids:
+                match_types[rid] = MatchType.BOTH
+            elif rid not in match_types:
+                match_types[rid] = MatchType.SEMANTIC
 
     # Sort by fused score
     all_ids = sorted(scores, key=lambda rid: scores[rid], reverse=True)
@@ -138,17 +209,13 @@ async def hybrid_search(
         if meta is None:
             continue
 
-        # Category filter
         if category and meta.get("category") != category.value:
             continue
 
-        # Tag filter
-        if tags:
-            recipe_tags: list[str] = json.loads(str(meta.get("tags", "[]")))
-            if not set(tags).intersection(recipe_tags):
-                continue
+        recipe_tags: list[str] = json.loads(str(meta.get("tags", "[]")))
+        if tags and not set(tags).intersection(recipe_tags):
+            continue
 
-        # Confidence filter
         nutr = nutrition_map.get(rid)
         if min_confidence > 0.0 and (nutr is None or nutr.confidence < min_confidence):
             continue
@@ -160,24 +227,9 @@ async def hybrid_search(
             fat_g=nutr.fat_g if nutr else 0.0,
         )
 
-        recipe_tags_parsed: list[str] = json.loads(str(meta.get("tags", "[]")))
-        cat_val = meta.get("category")
-        recipe_category = RecipeCategory(str(cat_val)) if cat_val else None
-
         hits.append(
-            RecipeSearchHit(
-                id=rid,
-                name=str(meta["name"]),
-                category=recipe_category,
-                tags=recipe_tags_parsed,
-                prep_minutes=(
-                    int(str(meta["prep_minutes"])) if meta.get("prep_minutes") is not None
-                    else None
-                ),
-                cook_minutes=(
-                    int(str(meta["cook_minutes"])) if meta.get("cook_minutes") is not None
-                    else None
-                ),
+            _build_hit(
+                row={**meta, "tags": json.dumps(recipe_tags)},
                 macro_summary=macro_summary,
                 search_score=scores[rid],
                 match_type=match_types.get(rid, MatchType.KEYWORD),
@@ -207,7 +259,6 @@ async def macro_distance_search(
     offset: int = 0,
 ) -> RecipeSearchPage:
     """Find recipes closest to target macros using weighted Euclidean distance."""
-    # Build query conditions
     conditions: list[str] = []
     params: list[str | float] = []
 
@@ -267,7 +318,6 @@ async def macro_distance_search(
 
         distance = math.sqrt(dist_sq / count)
 
-        # Tolerance filter
         if distance > tolerance_pct / 100.0:
             continue
 
@@ -279,26 +329,9 @@ async def macro_distance_search(
 
     hits: list[RecipeSearchHit] = []
     for row_dict, distance in page:
-        recipe_tags_parsed: list[str] = json.loads(str(row_dict.get("tags", "[]")))
-        cat_val = row_dict.get("category")
-        recipe_category = RecipeCategory(str(cat_val)) if cat_val else None
-
         hits.append(
-            RecipeSearchHit(
-                id=str(row_dict["id"]),
-                name=str(row_dict["name"]),
-                category=recipe_category,
-                tags=recipe_tags_parsed,
-                prep_minutes=(
-                    int(str(row_dict["prep_minutes"]))
-                    if row_dict.get("prep_minutes") is not None
-                    else None
-                ),
-                cook_minutes=(
-                    int(str(row_dict["cook_minutes"]))
-                    if row_dict.get("cook_minutes") is not None
-                    else None
-                ),
+            _build_hit(
+                row=row_dict,
                 macro_summary=MacroSummary(
                     calories=float(str(row_dict["calories"])),
                     protein_g=float(str(row_dict["protein_g"])),

--- a/backend/yes_chef_mcp/mcp/server.py
+++ b/backend/yes_chef_mcp/mcp/server.py
@@ -766,9 +766,9 @@ async def show_grocery_checklist(
 )
 def macro_setter_resource() -> str:
     """Interactive macro target editor UI."""
-    from yes_chef_mcp.views import DIST_DIR
+    from yes_chef_mcp.api.views import DIST_DIR, prepare_html
 
-    return (DIST_DIR / "macro-setter.html").read_text()
+    return prepare_html(DIST_DIR / "macro-setter.html")
 
 
 @mcp.resource(
@@ -777,9 +777,9 @@ def macro_setter_resource() -> str:
 )
 def recipe_selector_resource() -> str:
     """Recipe browser with card grid UI."""
-    from yes_chef_mcp.views import DIST_DIR
+    from yes_chef_mcp.api.views import DIST_DIR, prepare_html
 
-    return (DIST_DIR / "recipe-selector.html").read_text()
+    return prepare_html(DIST_DIR / "recipe-selector.html")
 
 
 @mcp.resource(
@@ -788,9 +788,9 @@ def recipe_selector_resource() -> str:
 )
 def weekly_calendar_resource() -> str:
     """Weekly meal plan calendar UI."""
-    from yes_chef_mcp.views import DIST_DIR
+    from yes_chef_mcp.api.views import DIST_DIR, prepare_html
 
-    return (DIST_DIR / "weekly-calendar.html").read_text()
+    return prepare_html(DIST_DIR / "weekly-calendar.html")
 
 
 @mcp.resource(
@@ -799,6 +799,7 @@ def weekly_calendar_resource() -> str:
 )
 def grocery_list_resource() -> str:
     """Grocery checklist UI."""
-    from yes_chef_mcp.views import DIST_DIR
+    from yes_chef_mcp.api.views import DIST_DIR, prepare_html
 
-    return (DIST_DIR / "grocery-list.html").read_text()
+    return prepare_html(DIST_DIR / "grocery-list.html")
+


### PR DESCRIPTION
- Rewrite asset paths to absolute URLs in HTML views to fix loading in sandboxed MCP environments.
- Enable CORS and replace `app.mount` with a manual static file route to ensure middleware applies.
- Add FTS5 query sanitization to prevent SQLite errors on special characters.
- Implement "browse mode" in hybrid search for empty queries.
- Refactor search hit building into a shared `_build_hit` helper.
- Update documentation and environment variables for the database path configuration.